### PR TITLE
docs: update deprecated addListener to addEventListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ describe('Your testing module' => {
     const secondListener = jest.fn();
     const mql = window.matchMedia(mediaQuery);
 
-    mql.addListener(ev => ev.matches && firstListener());
-    mql.addListener(ev => ev.matches && secondListener());
+    mql.addEventListener("change", ev => ev.matches && firstListener());
+    mql.addEventListener("change", ev => ev.matches && secondListener());
 
     matchMedia.useMediaQuery(mediaQuery);
 


### PR DESCRIPTION
@dyakovk Thanks for this lib, it's fantastic! After implementing the documentation code I noticed my linter screaming that `addListener` is deprecated. 

See [this SO post/answer](https://stackoverflow.com/a/56466334/5369706) for details. In particular, `addListener` should be updated to `addEventListener` and the event, `"change"`. 

I've forked here and updated the couple lines in the docs. Let me know if there's more to do here. Thanks!